### PR TITLE
Fixed exception raised running mango compile behaviour

### DIFF
--- a/Mobbex/Webpay/Controller/Payment/WebhookBase.php
+++ b/Mobbex/Webpay/Controller/Payment/WebhookBase.php
@@ -15,7 +15,7 @@ if (interface_exists('\Magento\Framework\App\CsrfAwareActionInterface')) {
          * @param RequestInterface $request
          * @return InvalidRequestException|null
          */
-        public function createCsrfValidationException(RequestInterface $request)
+        public function createCsrfValidationException(RequestInterface $request):InvalidRequestException
         {
             return null;
         }
@@ -24,7 +24,7 @@ if (interface_exists('\Magento\Framework\App\CsrfAwareActionInterface')) {
          * @param RequestInterface $request
          * @return bool|null
          */
-        public function validateForCsrf(RequestInterface $request)
+        public function validateForCsrf(RequestInterface $request):bool
         {
             return true;
         }


### PR DESCRIPTION
The following exception is raised running `bin/magento setup:di:compile` command.
The problem is an incompatible interface implementation.


```bash
$ bin/magento setup:di:compile

Compilation was started.
Repositories code generation... 1/7 [====>-----------------------]  14% < 1 sec 40.0 MiB
Fatal error: Declaration of Mobbex\Webpay\Controller\Payment\WebhookBase::createCsrfValidationException(Magento\Framework\App\RequestInterface $request) must be compatible with Magento\Framework\App\CsrfAwareActionInterface::createCsrfValidationException(Magento\Framework\App\RequestInterface $request): ?Magento\Framework\App\Request\InvalidRequestException in /var/www/html/app/code/Mobbex/Webpay/Controller/Payment/WebhookBase.php on line 11
```