### PR TITLE
Financing information on product page

### DIFF
--- a/Block/Product/Financial.php
+++ b/Block/Product/Financial.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+/**
+ * Product description block
+ *
+ * @author     
+ */
+namespace Mobbex\Webpay\Block\Product;
+
+use Magento\Customer\Model\Session;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\View\Element\Template\Context;
+use Mobbex\Webpay\Helper\Data;
+use Psr\Log\LoggerInterface;
+use Mobbex\Webpay\Helper\Config;
+use Magento\Catalog\Model\Product;
+
+/**
+ * @api
+ * @since 100.0.2
+ */
+class Financial extends \Magento\Framework\View\Element\Template
+{
+
+    /**
+     * @var Data
+     */
+    protected $_helper;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var Product
+     */
+    protected $_product = null;
+
+    /**
+     * Core registry
+     *
+     * @var \Magento\Framework\Registry
+     */
+    protected $_coreRegistry = null;
+
+    /**
+     * @param \Magento\Framework\View\Element\Template\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param array $data
+     * @param Mobbex\Webpay\Helper\Config $config
+     */
+    public function __construct(
+        \Magento\Framework\View\Element\Template\Context $context,
+        \Magento\Framework\Registry $registry,
+        array $data = [],
+        Config $config 
+    ) {
+        $this->_coreRegistry = $registry;
+        parent::__construct($context, $data);
+        $this->config = $config;
+    }
+
+    /**
+     * @return Product
+     */
+    public function getProduct()
+    {
+        if (!$this->_product) {
+            $this->_product = $this->_coreRegistry->registry('product');
+        }
+        return $this->_product;
+    }
+
+    /**
+     * @return String Apikey
+     */
+    public function getApikey(){
+        return $this->config->getApiKey();
+    }
+
+    /**
+     * Return the Cuit/Tax_id using the ApiKey to request via web service
+     * @return String Cuit
+     */
+    public function getCuit(){
+        $curl = curl_init();
+        $cuit = "";
+
+        $headers = $this->getHeaders();
+
+        curl_setopt_array($curl, [
+            CURLOPT_URL => "https://api.mobbex.com/p/entity/validate",
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_ENCODING => "",
+            CURLOPT_MAXREDIRS => 10,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+            CURLOPT_CUSTOMREQUEST => "GET",
+            CURLOPT_HTTPHEADER => $headers,
+        ]);
+
+        $response = curl_exec($curl);
+        $err = curl_error($curl);
+
+        curl_close($curl);
+
+        if ($err) {
+            //search the cuit in the plugins config if cant get it from api request
+            $cuit = $this->config->getCuit();
+        } else {
+            $res = json_decode($response, true);
+            $cuit = $res['data']['tax_id'];
+        }
+        return $cuit; 
+    }
+
+    /**
+     * Return true if the "Activar Info. Financiación" is set to "Si" or false if it's "No"
+     * @return array
+     */
+    public function getFinancialactive(){
+        return $this->config->getFinancialactive();
+    }
+
+
+    /**
+     * Build an array with the headers for an api request
+     * @return array
+     */
+    private function getHeaders()
+    {
+        return [
+            'cache-control: no-cache',
+            'content-type: application/json',
+            'x-api-key: ' . $this->config->getApiKey(),
+            'x-access-token: ' . $this->config->getAccessToken(),
+        ];
+    }
+
+}

--- a/Helper/Config.php
+++ b/Helper/Config.php
@@ -4,6 +4,16 @@ namespace Mobbex\Webpay\Helper;
 
 class Config extends \Magento\Framework\App\Helper\AbstractHelper
 {
+    const PATH_API_KEY = 'payment/webpay/api_key';
+    const PATH_ACCESS_TOKEN = 'payment/webpay/access_token';
+
+    const PATH_TEST_MODE = 'payment/webpay/test_mode';
+    const PATH_DEBUG_MODE = 'payment/webpay/debug_mode';
+    const PATH_EMBED_PAYMENT = 'payment/webpay/checkout/embed_payment';
+
+    const PATH_THEME_TYPE = 'payment/webpay/checkout/theme';
+    const PATH_BACKGROUND_COLOR = 'payment/webpay/checkout/background_color';
+    const PATH_PRIMARY_COLOR = 'payment/webpay/checkout/primary_color';
     const PATH_BANNER_CHECKOUT = 'payment/webpay/checkout/checkout_banner';
 
     const PATH_CREATE_ORDER_EMAIL = 'payment/webpay/checkout/email_settings/create_order_email';
@@ -82,6 +92,78 @@ class Config extends \Magento\Framework\App\Helper\AbstractHelper
     {
         return $this->scopeConfig->getValue(
             self::PATH_ORDER_STATUS_REFUNDED,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getThemeType($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_THEME_TYPE,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getBackgroundColor($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_BACKGROUND_COLOR,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getPrimaryColor($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_PRIMARY_COLOR,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getEmbedPayment($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_EMBED_PAYMENT,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getApiKey($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_API_KEY,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getAccessToken($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_ACCESS_TOKEN,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getTestMode($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_TEST_MODE,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
+            $store
+        );
+    }
+
+    public function getDebugMode($store = null)
+    {
+        return $this->scopeConfig->getValue(
+            self::PATH_DEBUG_MODE,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE,
             $store
         );

--- a/Model/CustomConfigProvider.php
+++ b/Model/CustomConfigProvider.php
@@ -42,7 +42,7 @@ class CustomConfigProvider implements ConfigProviderInterface
             'payment' => [
                 'webpay' => [
                     'config' => [
-                        'embed' => $this->_helper->mobbex->getEmbedPayment()
+                        'embed' => $this->config->getEmbedPayment()
                     ],
                     'banner' => $this->config->getBannerCheckout()
                 ]

--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -1,0 +1,10 @@
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="../../../../../../../lib/internal/Magento/Framework/View/Layout/etc/page_configuration.xsd">
+                <body>
+                    <referenceContainer name="page.wrapper">
+                        <block class="Mobbex\Webpay\Block\Product\Financial" 
+                            name="product.info.financialinfo" 
+                            template="Mobbex_Webpay::product/financialInformation.phtml" />   
+                    </referenceContainer>
+                    <move element="product.info.financialinfo" destination="product.info.addtocart" after="product.info.addtocart"/>
+                </body>
+</page>

--- a/view/frontend/templates/product/financialInformation.phtml
+++ b/view/frontend/templates/product/financialInformation.phtml
@@ -1,0 +1,115 @@
+<?php
+/** @var $block \Magento\Catalog\Block\Product\View */
+    $product = $block->getProduct();
+    $buttonTitle = __('Ver Financiación'); 
+    $price = $product->getPrice() ? : $product->getFinalPrice();
+    $isActiveFinancialInfo = $block->getFinancialactive();
+    $cuit =  $block->getCuit();// or tax_id
+    //stablish the initial url with only one product selected
+    $url_information = "https://mobbex.com/p/sources/widget/arg/".$cuit."/?total=".$price;
+?>
+
+<?php if ($product->isSaleable()) :?>
+    <Style>
+        /* The Modal (background) */
+        .modal {
+                    display: none; /* Hidden by default */
+                    position: fixed; /* Stay in place */
+                    z-index: 1; /* Sit on top */
+                    left: 0;
+                    top: 0;
+                    width: 100%; /* Full width */
+                    height: 100%; /* Full height */
+                    overflow: auto; /* Enable scroll if needed */
+                    background-color: rgb(0,0,0); /* Fallback color */
+                    background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+                    z-index: 9999;
+                }
+                
+                /* Modal Content/Box */
+                .modal-content {
+                    background-color: #fefefe;
+                    margin: 10% auto auto; /* 15% from the top and centered */
+                    padding: 20px;
+                    border: 1px solid #888;
+                    width: 60%; /* Could be more or less, depending on screen size */
+                    height: 100%; /* Full height */
+                    z-index: 10000;
+                }
+                /* The Close Button */
+                .close {
+                    color: #aaa;
+                    float: right;
+                    font-size: 28px;
+                    font-weight: bold;
+                }
+                
+                .close:hover,
+                .close:focus {
+                    color: black;
+                    text-decoration: none;
+                    cursor: pointer;
+                } 
+    </Style>
+
+    <?php if($isActiveFinancialInfo && $cuit>0) :?>
+        <!-- If the tax_id and active="Si" is set !-->
+        <div class="box-tocart">
+            <div class="fieldset">
+                <div class="actions">
+                    <!-- The Button !-->
+                    <button class="action primary tocart" id="myBtn">Ver Financiaciones</button>
+                    <?= $block->getChildHtml('', true) ?>
+                </div>
+            </div>
+        </div>
+    <?php endif; ?>
+    <!-- The Modal -->
+    <div id="myModal" class="modal">
+        <!-- Modal content -->
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <iframe id="iframe" src=<?php echo $url_information ?>></iframe>
+        </div>
+    </div>
+<?php endif; ?>
+<script>
+    var quantityDom = document.getElementsByClassName("qty");
+    // Get the modal
+    var modal = document.getElementById("myModal");
+    // Get the button that opens the modal
+    var btn = document.getElementById("myBtn");
+    // Get the <span> element that closes the modal
+    var span = document.getElementsByClassName("close")[0];
+    // When the user clicks on <span> (x), close the modal
+    span.onclick = function() {
+        modal.style.display = "none";
+    }
+    
+    // When the user clicks on the button, show/open the modal
+    btn.addEventListener('click', function(e) {
+        e.preventDefault();
+        var quantity = quantityDom.qty.value;
+        var price_one = <?php echo $price; ?>;
+        var tax_id = <?php echo $cuit; ?>;
+        //recalculate the price based on quantity
+        var total_price = price_one * quantity;
+        iframe.src = "https://mobbex.com/p/sources/widget/arg/"+tax_id+"/?total="+total_price;
+        modal.style.display = "block";
+        //set the modal and iframe style
+        window.dispatchEvent(new Event('resize'));
+        document.getElementById('iframe').style.width = "100%"; 
+        document.getElementById('iframe').style.height = "96%"; 
+        return false;
+    });
+
+    // When the user clicks anywhere outside of the modal, close it
+    window.onclick = function(event) {
+        if (event.target == modal) {
+            modal.style.display = "none";
+        }
+    } 
+
+    
+</script>
+

--- a/view/frontend/templates/product/financialInformation.phtml
+++ b/view/frontend/templates/product/financialInformation.phtml
@@ -32,7 +32,7 @@
                     margin: 10% auto auto; /* 15% from the top and centered */
                     padding: 20px;
                     border: 1px solid #888;
-                    width: 60%; /* Could be more or less, depending on screen size */
+                    max-width: 650px; /* Could be more or less, depending on screen size */
                     height: 100%; /* Full height */
                     z-index: 10000;
                 }


### PR DESCRIPTION
# Description

Added "Ver Financiación" button in the product page, now allows to view the financial information of the selected quantity of a product.


## Tasks
- [x] Add **Cuit** and **Activar Info. Financiación** on admin settings
- [x] Add "Ver Financiación" button
- [x] Get the selected quantity
- [x] Get the store Cuit/Tax_id using a web service
- [x] Display Iframe with financing information after button is click

# Tested

The plugin was tested in the following versions of Magento
- [x] 2.4.1