### PR TITLE
fix: Mobbex refunds dont generate Magento credit memos.

### DIFF
--- a/Block/Info.php
+++ b/Block/Info.php
@@ -27,9 +27,10 @@ class Info extends \Magento\Payment\Block\Info
         )
     {
         parent::__construct($context, $data);
-        $instantiator->setProperties($this, ['mobbexTransactionFactory']);
+        $instantiator->setProperties($this, ['mobbexTransactionFactory', 'customFieldFactory']);
         $this->_state = $_state;
         $this->mobbexTransaction = $this->mobbexTransactionFactory->create();
+        $this->customField       = $this->customFieldFactory->create();
     }
 
     /**
@@ -51,7 +52,8 @@ class Info extends \Magento\Payment\Block\Info
 
         $data = [
             (string) __('Transaction ID') => isset($mobbexData['payment_id']) ? $mobbexData['payment_id'] : '',
-            (string) __('Total')          => isset($mobbexData['total']) ? $mobbexData['total'] : '',
+            (string) __('Total')          => '$'.(isset($mobbexData['total']) ? $mobbexData['total'] : '0'),
+            (string) __('Total Refunded') => '$'.($this->customField->getCustomField($this->getInfo()->getOrder()->getIncrementId(), 'order', 'total_refunded') ?: '0'),
         ];
 
         if($cards){
@@ -61,7 +63,7 @@ class Info extends \Magento\Payment\Block\Info
                     $data[(string) __('Card') . ' ' . ($key + 1)]                = isset($card['source_name']) ? $card['source_name'] : '';
                     $data[(string) __('Card') . ' ' . ($key + 1).' Number']      = isset($card['source_number']) ? $card['source_number'] : '';
                     $data[(string) __('Card') . ' ' . ($key + 1).' Installment'] = !empty($card['source_installment']) ? json_decode($card['source_installment'], true)['description'] . ' ' . json_decode($card['source_installment'], true)['count'] . ' cuota/s' : '';
-                    $data[(string) __('Card') . ' ' . ($key + 1).' Amount']      = isset($card['total']) ? $card['total'] : '';
+                    $data[(string) __('Card') . ' ' . ($key + 1).' Amount']      = '$'.(isset($card['total']) ? $card['total'] : '0');
                 }
             }
         } else {

--- a/Controller/Payment/Webhook.php
+++ b/Controller/Payment/Webhook.php
@@ -96,13 +96,13 @@ class Webhook extends \Mobbex\Webpay\Controller\Payment\WebhookBase
         
         //Get previous refunds
         $totalRefunded = (int) $this->customField->getCustomField($data['order_id'], 'order', 'total_refunded') + $data['total'];
-        $paidTotal     = $this->_order->getGrandTotal() - $totalRefunded;
+        $totalPaid     = $this->_order->getGrandTotal() - $totalRefunded;
 
         //Save total refunded
         $this->customField->saveCustomField($data['order_id'], 'order', 'total_refunded', $totalRefunded);
 
-        if ($data['parent'] || $paidTotal <= 0){
-            $this->orderUpdate->createCreditMemo($this->_order);
+        if ($data['parent'] || $totalPaid <= 0){
+            $this->orderUpdate->cancelOrder($this->_order);
             $this->orderUpdate->updateStatus($this->_order, $data);
         }
 

--- a/Controller/Payment/Webhook.php
+++ b/Controller/Payment/Webhook.php
@@ -61,7 +61,7 @@ class Webhook extends \Mobbex\Webpay\Controller\Payment\WebhookBase
             //Save webhook data en database
             $this->mobbexTransaction->saveTransaction($data);
 
-            if($data['status_code'] === '602' || $data['status_code'] === '603')
+            if(in_array($data['status_code'], ['601', '602', '603', '604', '605', '610']))
                 return $this->processRefund($data, $orderId);
 
             if($data['parent'] == false)

--- a/Model/OrderUpdate.php
+++ b/Model/OrderUpdate.php
@@ -305,6 +305,10 @@ class OrderUpdate
         return $this->createCreditMemo($order);
     }
 
+    /**
+     * Creates a Magento Credit Memo for a given order
+     * @param Order $order
+     */
     public function createCreditMemo($order)
     {
         $invoices = $order->getInvoiceCollection() ?: [];

--- a/Model/OrderUpdate.php
+++ b/Model/OrderUpdate.php
@@ -301,7 +301,12 @@ class OrderUpdate
         // Exit if it is not refundable
         if (!$order->canCreditmemo())
             return;
+        
+        return $this->createCreditMemo($order);
+    }
 
+    public function createCreditMemo($order)
+    {
         $invoices = $order->getInvoiceCollection() ?: [];
 
         foreach ($invoices as $invoiceResource)
@@ -309,11 +314,11 @@ class OrderUpdate
 
         if (empty($invoiceId))
             return;
-    
+
         // Instance invoice and create credit memo
         $invoice    = $this->invoice->loadByIncrementId($invoiceId);
         $creditmemo = $this->creditmemoFactory->createByOrder($order)->setInvoice($invoice);
-    
+
         // Back to stock all the items
         foreach ($creditmemo->getAllItems() as $item)
             $item->setBackToStock(true);

--- a/Model/OrderUpdate.php
+++ b/Model/OrderUpdate.php
@@ -306,8 +306,11 @@ class OrderUpdate
     }
 
     /**
-     * Creates a Magento Credit Memo for a given order
+     * Creates a Magento Credit Memo for a given order.
+     * 
      * @param Order $order
+     * 
+     * @return \Magento\Sales\Model\Order\Creditmemo
      */
     public function createCreditMemo($order)
     {


### PR DESCRIPTION
# Notas
* Añadida la generación de credit memos en devoluciones totales.
* Añadida la generación de credit memos en devoluciones parciales que alcancen el total de la operación.