### PR TITLE
fix issue: #182, when own images with sources domain that ends with res.mobbex.com are restricted by CSP

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -16,5 +16,10 @@
                 <value id="mobbex" type="host">https://mobbex.com</value>
             </values>
         </policy>
+        <policy id="img-src">
+            <values>
+                <value id="mobbex" type="host">*.mobbex.com</value>
+            </values>
+        </policy>
     </policies>
 </csp_whitelist>


### PR DESCRIPTION
fix issue: #182, when own images with sources domain that ends with res.mobbex.com are restricted by CSP  